### PR TITLE
[BOJ]2529/실버1/252ms/40min/김영표

### DIFF
--- a/Youngpyo_Kim/BOJ_2529_부등호.java
+++ b/Youngpyo_Kim/BOJ_2529_부등호.java
@@ -1,0 +1,55 @@
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.*;
+
+public class BOJ_2529_부등호 {
+    static int k;
+    static char[] question = new char[10];
+    static int number[] = {0,1,2,3,4,5,6,7,8,9};
+    static ArrayList<String> ans = new ArrayList<>(100);
+
+    static boolean check(int charidx, int curN, int prevN){
+        if(question[charidx] == '<')
+            return prevN < curN;
+        else
+            return prevN > curN;
+    }
+
+    static void bt(int charidx, int prev, String cur, boolean[] visited){
+        if(charidx == k){
+            ans.add(cur);
+            return;
+        }
+
+        for(int i = 0; i< 10; i++){
+            if(!visited[i] && check(charidx, i, prev)){
+                visited[i] = true;
+                bt(charidx + 1, i, cur+i, visited);
+                visited[i] = false;
+            }
+        }
+
+        return;
+    }
+
+    public static void main(String[] args) throws Exception {
+        BufferedReader in = new BufferedReader(new InputStreamReader(System.in));
+        k = Integer.parseInt(in.readLine());
+        
+        StringTokenizer st = new StringTokenizer(in.readLine());
+
+        for(int i = 0; i < k; i++){
+            question[i] = st.nextToken().charAt(0);
+        }
+        
+        for(int i = 0; i < 10; i++){
+            boolean[] visited = new boolean[10];
+            visited[i] = true;
+            bt(0, i, Integer.toString(i), visited);
+        }
+
+        Collections.sort(ans);
+        System.out.println(ans.get(ans.size()-1));
+        System.out.println(ans.get(0));
+    }
+}


### PR DESCRIPTION
[Backtracking]
- K도 9까지이고 숫자도 중복이 안되니 시간을 고려하지 않고 완전탐색으로 구현만 하면 됩니다.
- 통과는 됐지만, 코드는 그렇게 깔끔하진 않습니다.
- 알고리즘 자체는 간단합니다.
   - 숫자 중복을 피하기 위해 visited 배열을 들고다니면서 visited[i]가 사용하지 않은 숫자일때, 부등호에 맞을때 참으로 바꿔주고 다음 depths로 넘어가면 됩니다. 이후에 return을 받았을 때에 visited[i]를 다시 거짓으로 바꿔주면 됩니다.
   - 이런식으로 구현하면 모든 경우의 수를 확인합니다.
- 완전탐색을 쉽게 푸는 방법은 재귀 함수의 끝을 정해놓고 시작하는 것입니다.  