### PR TITLE
[BOJ]2910/실버3/340ms/30m/김영표

### DIFF
--- a/Youngpyo_Kim/BOJ_2910_빈도정렬.java
+++ b/Youngpyo_Kim/BOJ_2910_빈도정렬.java
@@ -1,0 +1,37 @@
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.*;
+
+// 340ms
+public class BOJ_2910_빈도정렬 {
+    public static void main(String[] args) {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		int n = Integer.parseInt(st.nextToken());
+		int c = Integer.parseInt(st.nextToken());
+		st = new StringTokenizer(br.readLine());
+		
+        HashMap<Integer, Integer> cnt = new HashMap<>();
+        HashMap<Integer, Integer> valToIdx = new HashMap<>();
+
+        for(int i = 1; i <= n; i++) {
+			int tmp = Integer.parseInt(st.nextToken());
+            cnt.put(tmp, cnt.getOrDefault(tmp, 0) + 1);
+            if (valToIdx.get(tmp) == null)
+                valToIdx.put(tmp, i);
+        }
+
+        List<Map.Entry<Integer, Integer>> arr = new ArrayList<>(cnt.entrySet());
+        arr.sort((a, b) -> {
+            if (!a.getValue().equals(b.getValue())) {
+                return b.getValue().compareTo(a.getValue());
+            }
+            return valToIdx.get(a.getKey()).compareTo(valToIdx.get(b.getKey()));
+        });
+
+        for (Map.Entry<Integer, Integer> entry : arr) {
+            for (int i = 0; i < entry.getValue(); i++)
+                System.out.print(entry.getKey() + " ");
+        }
+    }
+}


### PR DESCRIPTION
[자료구조/해시맵]
- 일반적인 빈도정렬을 하기에는 C의 범위가 너무 커서 해시맵을 이용해야하는 문제.
- 해쉬맵을 이용하자니 빈도가 같은 것들은 Index가 작은 걸 출력해야해서 Value -> Index 변환이 가능한 해시맵을 하나 더 사용해야합니다.