### PR TITLE
[BOJ]17182/골드3/188ms/2시간/황제철

### DIFF
--- a/Jecheol_Hwang/BOJ_17182_우주탐사선.java
+++ b/Jecheol_Hwang/BOJ_17182_우주탐사선.java
@@ -10,7 +10,7 @@ public class BOJ_17182_우주탐사선 {
     *
     * 메모리 : 15912 MB
     *
-    * 시간복잡도 : O(N^3 * N!); 플로이드와셜 * 넥퍼
+    * 시간복잡도 : O(N^3 + N!); 플로이드와셜 + 넥퍼
     * */
     public static void main(String[] args) throws IOException {
         BufferedReader br = new BufferedReader(new InputStreamReader(System.in));

--- a/Jecheol_Hwang/BOJ_17182_우주탐사선.java
+++ b/Jecheol_Hwang/BOJ_17182_우주탐사선.java
@@ -6,12 +6,13 @@ import java.util.StringTokenizer;
 
 public class BOJ_17182_우주탐사선 {
     /*
+    * 티어 : 골드3
+    *
     * 수행 시간 : 188 ms
     *
     * 메모리 : 15912 MB
     *
     * 시간복잡도 : O(N^3 * N!); 플로이드와셜 * 넥퍼
-    *
     * */
     public static void main(String[] args) throws IOException {
         BufferedReader br = new BufferedReader(new InputStreamReader(System.in));

--- a/Jecheol_Hwang/BOJ_17182_우주탐사선.java
+++ b/Jecheol_Hwang/BOJ_17182_우주탐사선.java
@@ -11,6 +11,7 @@ public class BOJ_17182_우주탐사선 {
     * 메모리 : 15912 MB
     *
     * 시간복잡도 : O(N^3 * N!); 플로이드와셜 * 넥퍼
+    *
     * */
     public static void main(String[] args) throws IOException {
         BufferedReader br = new BufferedReader(new InputStreamReader(System.in));


### PR DESCRIPTION
## 해석

"중복으로 노드를 방문 가능하다"에 주목했고, 플로이드 워셜 쓰는 문제구나 했습니다.

처음에는 최소 시간이라 DP를 써야 하나 하는 고민을 한참 하다가, "어차피 DP 쓰라고 해도 난 못 쓴다." 라는 결론 하에

N이 10 까지라서 대충 시간복잡도 계산해봤을 때 순열로 죄다 검사해도 시간 안에 들어오겠다 생각해서 넥퍼를 같이 적용해 봤습니다.

결론 : 플로이드워셜로 각 노드 간 최적 weight 갱신 + visited 와 np를 활용한 완전탐색

- 시간복잡도 : O(N^3 + N!)
- 수행 시간 : 188 ms
- 메모리 : 15192 KB