### PR TITLE
[PGS]숫자타자대회/50min/김영표

### DIFF
--- a/Youngpyo_Kim/BOJ_2705_팰린드롬파티션.java
+++ b/Youngpyo_Kim/BOJ_2705_팰린드롬파티션.java
@@ -19,7 +19,7 @@ public class BOJ_2705_팰린드롬파티션 {
                 dp[i] = dp[i - 2] + dp[i / 2];
             }
         }
-
+  
         while (t-- > 0) {
             n = Integer.parseInt(br.readLine());
             System.out.println(dp[n]);

--- a/Youngpyo_Kim/PSG_숫자타자게임.java
+++ b/Youngpyo_Kim/PSG_숫자타자게임.java
@@ -1,0 +1,60 @@
+class Solution {
+    int[][] minimum_step;
+    int[][][] dp;
+    String tmp;
+
+    int memo_dp(int idx, int left, int right) {
+        if (idx >= tmp.length())
+            return 0;
+
+        if (dp[idx][left][right] != 0) return dp[idx][left][right];
+
+        int cur = tmp.charAt(idx) - '0';
+
+        if (left == cur || right == cur) {
+            return 1 + memo_dp(idx + 1, left, right);
+        }
+
+        return dp[idx][left][right] = Math.min(memo_dp(idx + 1, cur, right) + minimum_step[left][cur], memo_dp(idx + 1, left, cur) + minimum_step[right][cur]);
+    }
+    
+    public int solution(String numbers) {
+        
+        int n = numbers.length();
+        minimum_step = new int[10][10];
+        dp = new int[n+1][10][10];
+        
+        for (int i = 0; i < 10; i++) {
+            int r, c;
+            if (i == 0){
+                r = 3;
+                c = 1;
+            }
+            else{
+                r = (i - 1) / 3;
+                c = (i - 1) % 3;
+            }
+            for (int j = 0; j < 10; j++) {
+                if (i == j) {
+                    minimum_step[i][j] = 1;
+                    continue;
+                }
+                int nr, nc;
+                if (j == 0){
+                    nr = 3;
+                    nc = 1;
+                }
+                else{
+                    nr = (j - 1) / 3;
+                    nc = (j - 1) % 3;
+                }
+                int diffr = Math.abs(r - nr), diffc = Math.abs(c - nc);
+
+                minimum_step[i][j] = 3 * Math.min(diffr, diffc) + 2 * Math.abs(diffr - diffc);
+            }
+        }
+        tmp = numbers;
+
+	    return memo_dp(0, 4, 6);
+    }
+}


### PR DESCRIPTION
[재귀/top down dp/memoization]
- N이 10^5 이길래 dp를 의심했습니다. 문제를 읽어보니 왼손과 오른손이 누를 수 있는 경우의 수가 2^10만이라서 시간을 생각하며 풀어야합니다. idx번째 숫자를 왼손으로 누르냐 오른손으로 누르냐에 따라 idx+1,+2,+3에 최소 움직임이 달라지기 때문에 idx번째에 왼손 오른손 위치에 최소 움직임을 저장하면서 탐색을 해야합니다.
- dp 문제를 풀 때, 저는 항상 dp table을 어떻게 구성할 것인가? dp table[i]가 의미하는 것은 무엇인가?, 이 둘을 먼저 생각하고 구현하는 편입니다.
- 편하게 구하기 위해서 처음에 minimum_step[10][10]을 이용해서 숫자->숫자로 갈 때에 최소 움직임을 먼저 구한 뒤에 재귀dp를 이용했습니다. 저 minimum_step을 구할 때에 bfs를 이용할 수도 있겠지만, 어차피 숫자 위치는 고정이라서 좌표 하나하나 본 뒤, 수학적으로 규칙을 찾아 이중 for문으로 구해줬습니다.
- 재귀 dp를 할 때에는 우리가 배웠던 완탐을 하면서 pruning하는 것과 비슷하게 하면 됩니다. 가지를 치는 조건은 idx가 string size를 넘어갈때, 이미 dp[idx][left][right]값이 우리가 구한 값일 때 입니다. 또한 재귀를 타는 경우가 3가지(움직이지 않는 경우, 왼손 움직이는 경우, 오른손 움직이는 경우)인데, 움직이지 않으면 그것이 최소 움직임이니 따로 Math.min()을 해주지 않고 재귀를 타면 됩니다. 