### PR TITLE
[BOJ]23796/골드5/124ms/1시간/황제철

### DIFF
--- a/Jecheol_Hwang/BOJ_1013_Contact.java
+++ b/Jecheol_Hwang/BOJ_1013_Contact.java
@@ -1,0 +1,17 @@
+package 알고리즘연습.boj;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+public class BOJ_1013_Contact {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int n = Integer.parseInt(br.readLine());
+
+        for (int i = 0; i < n; i++) {
+            String s = br.readLine();
+            System.out.println(s.matches("(100+1+|01)+") ? "YES" : "NO");
+        }
+    }
+}

--- a/Jecheol_Hwang/BOJ_1182_부분수열의합.java
+++ b/Jecheol_Hwang/BOJ_1182_부분수열의합.java
@@ -1,0 +1,41 @@
+package 알고리즘연습.boj;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class BOJ_1182_부분수열의합 {
+    private static int N, S;
+    private static int[] arr;
+    private static int ans;
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+
+        st = new StringTokenizer(br.readLine());
+
+        N = Integer.parseInt(st.nextToken());
+        S = Integer.parseInt(st.nextToken());
+        arr = new int[N];
+
+        st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < N; i++) {
+            arr[i] = Integer.parseInt(st.nextToken());
+        }
+        go(0, 0, 0);
+        System.out.println(ans);
+    }
+
+    private static void go(int cnt, int sum, int visited) {
+        if (cnt == N) {
+            if (sum == S && visited != 0) { // 최소 한개는 고르도록
+                ans++;
+            }
+            return;
+        }
+
+        go(cnt + 1, sum + arr[cnt], visited | 1 << cnt);
+        go(cnt + 1, sum, visited);
+    }
+}

--- a/Jecheol_Hwang/BOJ_14500_테트로미노.java
+++ b/Jecheol_Hwang/BOJ_14500_테트로미노.java
@@ -1,0 +1,127 @@
+package 알고리즘연습.boj;
+
+import java.io.*;
+import java.util.Comparator;
+import java.util.PriorityQueue;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
+/**
+ * 폴리오미노 : 크기가 1x1인 정사각형을 여러 개 이어서 붙인 도형
+ * 1. 정사각형은 서로 겹치면 안된다.
+ * 2. 도형은 모두 연결되어 있어야 한다.
+ * 3. 정사각형의 변끼리 연결되어 있어야 한다.
+ *
+ * 정사각형 4개를 이어 붙인 폴리오미노를 테트로미노라고 함
+ * 테트로미노 하나를 적절히 놓아서 테트로미노가 놓인 칸에 쓰여 있는 수들의 합을 최대로 하는 프로그램을 작성하라.
+ *
+ * 종이의 세로 N (500 이하) , 가로 M (500 이하)
+ *
+ * @intuition 전체 탐색해도 문제 없겠다.
+ * @algorithm 백트래킹 완탐
+ * @time O(NM) : 시작점 선정하고 재귀 탐색 + 볼록블록 별도 탐색 -> 784 ms
+ * @memory O(NM) -> 43908 kB
+ */
+public class BOJ_14500_테트로미노 {
+    private static boolean[][] visited;
+    private static int N, M;
+    private static int[][] map;
+    private static int[] dy = {1, -1, 0, 0};
+    private static int[] dx = {0, 0, 1, -1};
+    private static int ans;
+    private static Queue<int[]> pq = new PriorityQueue<>(Comparator.comparingInt(o -> o[2]));
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+        StringBuilder sb = new StringBuilder();
+        StringTokenizer st;
+
+        st = new StringTokenizer(br.readLine());
+        N = Integer.parseInt(st.nextToken());
+        M = Integer.parseInt(st.nextToken());
+        map = new int[N][M];
+        visited = new boolean[N][M];
+
+        for (int i = 0; i < N; i++) {
+            st = new StringTokenizer(br.readLine());
+            for (int j = 0; j < M; j++) {
+                int num = Integer.parseInt(st.nextToken());
+                map[i][j] = num;
+            }
+        }
+
+        for (int i = 0; i < N; i++) {
+            for (int j = 0; j < M; j++) {
+                visited[i][j] = true;
+                go(i, j, map[i][j], 1);
+                visited[i][j] = false;
+                fuBlock(i, j);
+            }
+        }
+
+        sb.append(ans);
+        bw.write(sb.toString());
+        br.close();
+        bw.flush();
+        bw.close();
+    }
+
+    private static void go(int y, int x, int res, int depth) {
+        if (depth == 4) {
+            if (ans < res) {
+                ans = res;
+            }
+            return;
+        }
+        for (int i = 0; i < 4; i++) {
+            int ny = y + dy[i];
+            int nx = x + dx[i];
+            if (canGo(ny, nx)) {
+                visited[ny][nx] = true;
+                go(ny, nx, res + map[ny][nx], depth+1);
+                visited[ny][nx] = false;
+            }
+        }
+    }
+
+    private static boolean inRange(int y, int x) {
+        return y >= 0 && y < N && x >= 0 && x < M;
+    }
+
+    private static boolean canGo(int y, int x) {
+        return inRange(y, x) && !visited[y][x];
+    }
+
+    private static void fuBlock(int y, int x) {
+        int up = 0, down = 0, left = 0, right = 0, center = 0;
+        center = map[y][x];
+        if (inRange(y - 1, x)) {
+            up = map[y-1][x];
+        }
+        if (inRange(y, x - 1)) {
+            left = map[y][x-1];
+        }
+        if (inRange(y, x + 1)) {
+            right = map[y][x+1];
+        }
+        if (inRange(y + 1, x)) {
+            down = map[y + 1][x];
+        }
+        int[] arr = {up, down, left, right};
+        comb(0, 0, center, arr);
+    }
+
+    private static void comb(int cnt, int start, int res, int[] arr) {
+        if (cnt == 3) {
+            if (ans < res) {
+                ans = res;
+            }
+            return;
+        }
+        for (int i = start; i < 4; i++) {
+            if (arr[i] != 0) {
+                comb(cnt + 1, i + 1, res + arr[i], arr);
+            }
+        }
+    }
+}

--- a/Jecheol_Hwang/BOJ_14502_연구소.java
+++ b/Jecheol_Hwang/BOJ_14502_연구소.java
@@ -1,0 +1,128 @@
+package 알고리즘연습.boj;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.*;
+
+
+/**
+ * 빈 칸의 개수는 최소 3개 이상
+ * 바이러스는 상하좌우로 인접 빈칸으로 퍼짐
+ * 새로 세울 수 있는 벽의 개수가 3개, 반드시 3개를 세워야 함
+ * N과 M의 최대값이 both 8
+ *
+ * @algorithm bruteforce (combination + bfs)
+ * @time O((NM)^3 * NM) -> 516 ms
+ * @memory O(NM) -> 116448 KB
+ * 
+ * N과 M이 최대 8이므로 NM의 4제곱이여도 가능하다 판단
+ */
+public class BOJ_14502_연구소 {
+    private static int N, M;
+    private static int[][] arr;
+    private static boolean[][] visited;
+    private static Queue<int[]> q;
+    private static List<int[]> starts = new ArrayList<>();
+    private static List<int[]> availables = new ArrayList<>();
+    private static int ans;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        N = Integer.parseInt(st.nextToken());
+        M = Integer.parseInt(st.nextToken());
+        arr = new int[N][M];
+        for (int i = 0; i < N; i++) {
+            st = new StringTokenizer(br.readLine());
+            for (int j = 0; j < M; j++) {
+                arr[i][j] = Integer.parseInt(st.nextToken());
+            }
+        }
+
+
+        arr = new int[N][M];
+
+        for (int i = 0; i < N; i++) {
+            st = new StringTokenizer(br.readLine());
+            for (int j = 0; j < M; j++) {
+                arr[i][j] = Integer.parseInt(st.nextToken());
+                if (arr[i][j] == 2) {
+                    starts.add(new int[]{i, j});
+                } else if (arr[i][j] == 0) {
+                    availables.add(new int[]{i, j});
+                }
+            }
+        }
+
+        comb(0, 0);
+
+        System.out.println(ans);
+    }
+
+    private static void comb(int cnt, int start) {
+        if (cnt == 3) {
+            // business - bfs
+            bfs();
+            return;
+        }
+        for (int i = start; i < availables.size(); i++) {
+            int[] a = availables.get(i);
+            int y = a[0];
+            int x = a[1];
+            if (arr[y][x] == 0) {
+                arr[y][x] = 1;
+                comb(cnt + 1, i + 1);
+                arr[y][x] = 0;
+            }
+        }
+    }
+
+    private static void bfs() {
+        int[] dy = {0, 1, 0, -1};
+        int[] dx = {1, 0, -1, 0};
+        visited = new boolean[N][M];
+        q = new ArrayDeque<>();
+        int[][] temp = new int[N][M];
+        for (int i = 0; i < N; i++) {
+            temp[i] = arr[i].clone(); // 배열 복사
+        }
+        for (int[] start : starts) {
+            q.add(start);
+        }
+
+        while (!q.isEmpty()) {
+            int[] now = q.poll();
+            int y = now[0];
+            int x = now[1];
+            for (int i = 0; i < 4; i++) {
+                int ny = y + dy[i];
+                int nx = x + dx[i];
+                if (canGo(ny, nx, temp)) {
+                    temp[ny][nx] = 2;
+                    visited[ny][nx] = true;
+                    q.add(new int[]{ny, nx});
+                }
+            }
+        }
+
+        int cnt = 0;
+        for (int i = 0; i < N; i++) {
+            for (int j = 0; j < M; j++) {
+                if (temp[i][j] == 0) {
+                    cnt++;
+                }
+            }
+        }
+        ans = Math.max(ans, cnt);
+
+    }
+
+    private static boolean inRange(int y, int x) {
+        return y >= 0 && y < N & x >= 0 && x < M;
+    }
+
+    private static boolean canGo(int y, int x, int[][] temp) {
+        return inRange(y, x) && temp[y][x] != 1 && !visited[y][x];
+    }
+}

--- a/Jecheol_Hwang/BOJ_1520_내리막길.java
+++ b/Jecheol_Hwang/BOJ_1520_내리막길.java
@@ -1,0 +1,72 @@
+BOJ_21609_상어중학교package 알고리즘연습.boj;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+/**
+ * @intuition 경우의 수 저장 배열 선언하고, 이동 가능하면 경우의 수 배열 갱신
+ *
+ * @algorithm DP
+ * @time O(NM) 델타탐색 + 메모이제이션 -> 380ms
+ * @memory O(NM) M by N 배열 사용 -> 24964 KB
+ */
+
+// DFS 시도 -> timeout
+public class BOJ_1520_내리막길 {
+    private static int[][] height; // 높이 저장
+    private static int[][] dp; // 해당 위치로 이동할 수 있는 최대 경우의 수
+    private static int M, N; // M : 세로 , N : 가로 (500이하 자연수)
+    private static int H; // 정답 (이동 가능한 경로의 수 - 10억 이하의 음이 아닌 정수);
+    private static int[] dy = {0, 1, 0, -1};
+    private static int[] dx = {1, 0, -1, 0};
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+
+        st = new StringTokenizer(br.readLine());
+        M = Integer.parseInt(st.nextToken());
+        N = Integer.parseInt(st.nextToken());
+
+        // 높이배열 초기화
+        height = new int[M][N];
+        for (int i = 0; i < M; i++) {
+            st = new StringTokenizer(br.readLine());
+            for (int j = 0; j < N; j++) {
+                height[i][j] = Integer.parseInt(st.nextToken());
+            }
+        }
+
+        // DP 초기화
+        dp = new int[M][N];
+        for (int i = 0; i < M; i++) {
+            for (int j = 0; j < N; j++) {
+                dp[i][j] = -1;
+            }
+        }
+        dp[0][0] = 1;
+        
+        int ans = go(M - 1, N - 1, 0);
+        System.out.println(ans);
+    }
+
+    private static int go(int y, int x, int nextHeight) {
+        if (!inRange(y, x)) {
+            return 0;
+        }
+        int curHeight = height[y][x];
+        if (nextHeight >= curHeight) {
+            return 0;
+        }
+        if (dp[y][x] != -1) {
+            return dp[y][x];
+        }
+        return dp[y][x] = go(y - 1, x, curHeight) + go(y, x - 1, curHeight) + go(y + 1, x, curHeight) + go(y, x + 1, curHeight);
+    }
+
+    private static boolean inRange(int y, int x) {
+        return y >= 0 && y < M && x >= 0 && x < N;
+    }
+
+}

--- a/Jecheol_Hwang/BOJ_1647_도시분할계획.java
+++ b/Jecheol_Hwang/BOJ_1647_도시분할계획.java
@@ -1,0 +1,90 @@
+package 알고리즘연습.boj;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Comparator;
+import java.util.PriorityQueue;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
+/**
+ * @algorithm kruskal
+ * @time O(M * logM) ; 모든 간선 정렬 O(M * logM) + 각 간선에 대한 union-find O(E * logN)
+ *
+ * N : 노드의 개수 (2이상 100,000이하)
+ * M : 간선의 개수 (1이상 1,000,000이하)
+ */
+public class BOJ_1647_도시분할계획 {
+    private static int N, M;
+    private static int[] parent;
+    private static Queue<Edge> pq = new PriorityQueue<>(Comparator.comparingInt(o -> o.w));
+
+    private static class Edge {
+        int u,v, w;
+
+        public Edge(int u, int v, int w) {
+            this.u = u;
+            this.v = v;
+            this.w = w;
+        }
+    }
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        N = Integer.parseInt(st.nextToken());
+        M = Integer.parseInt(st.nextToken());
+        parent = new int[N + 1];
+        for (int i = 1; i <= N; i++) {
+            parent[i] = i;
+        }
+        for (int i = 0; i < M; i++) {
+            st = new StringTokenizer(br.readLine());
+            int u = Integer.parseInt(st.nextToken());
+            int v = Integer.parseInt(st.nextToken());
+            int w = Integer.parseInt(st.nextToken());
+            pq.add(new Edge(u, v, w));
+        }
+
+        int cnt = 0;
+        int ans = 0;
+        int bridge = 0;
+        while (!pq.isEmpty()) {
+            Edge e = pq.poll();
+            int u = e.u;
+            int v = e.v;
+            int w = e.w;
+            if (find(u) == find(v)) {
+                continue;
+            }
+            ans += w;
+            cnt++;
+            if (cnt == N - 1) {
+                bridge = w;
+                break;
+            }
+            union(u, v);
+        }
+        System.out.println(ans - bridge);
+    }
+
+    private static int find(int v) {
+        if (parent[v] == v) {
+            return v;
+        }
+        return parent[v] = find(parent[v]);
+    }
+
+    private static void union(int u, int v) {
+        int uRoot = find(u);
+        int vRoot = find(v);
+        if (uRoot == vRoot) {
+            return;
+        }
+        if (uRoot < vRoot) {
+            parent[vRoot] = uRoot;
+        } else {
+            parent[uRoot] = vRoot;
+        }
+    }
+}

--- a/Jecheol_Hwang/BOJ_16928_뱀과사다리게임.java
+++ b/Jecheol_Hwang/BOJ_16928_뱀과사다리게임.java
@@ -1,0 +1,68 @@
+package 알고리즘연습.boj;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.*;
+
+/**
+ * @algorithm BFS
+ * @time O(N)
+ * @memory O(N)
+ */
+public class BOJ_16928_뱀과사다리게임 {
+    // 1번부터 100번 칸까지 가는 문제
+    // 규칙 1 : 사다리가 있는 칸에 '도착'하면 자동으로 올라감
+    // 규칙 2 : 뱀이 있는 칸에 '도착'하면 자동으로 내려감
+
+    private static int N, M;
+    private static int[] map;
+    private static boolean[] visited;
+    private static Map<Integer, Integer> link = new HashMap<>(); // 희소할 수 있어서 배열보단 딕셔너리가 적절할 것으로 보았음
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+        st = new StringTokenizer(br.readLine());
+        N = Integer.parseInt(st.nextToken());
+        M = Integer.parseInt(st.nextToken());
+        map = new int[101];
+        Arrays.fill(map, (int) 1e9);
+        map[1] = 0;
+        visited = new boolean[101];
+
+        for (int i = 0; i < N + M; i++) {
+            st = new StringTokenizer(br.readLine());
+            int from = Integer.parseInt(st.nextToken());
+            int to = Integer.parseInt(st.nextToken());
+            link.put(from, to);
+        }
+        bfs();
+        System.out.println(map[100]);
+    }
+    private static void bfs() {
+        Queue<Integer> q = new ArrayDeque<>();
+        q.add(1); // start point
+        while (!q.isEmpty()) {
+            Integer now = q.poll();
+            if (visited[now]) {
+                continue;
+            }
+            visited[now] = true;
+            if (now == 100) {
+                return;
+            }
+            if (link.containsKey(now)) {
+                Integer next = link.get(now);
+                q.add(next);
+                map[next] = Math.min(map[next],map[now]);
+                continue; // 사다리나 뱀을 반드시 타야하므로, 해당 칸이 링크면 주사위 안굴리고 종료
+            }
+            for (int i = 1; i <= 6; i++) {
+                if (now + i <= 100) {
+                    q.add(now + i);
+                    map[now + i] = Math.min(map[now] + 1, map[now + i]);
+                }
+            }
+        }
+    }
+}

--- a/Jecheol_Hwang/BOJ_17144_미세먼지안녕.java
+++ b/Jecheol_Hwang/BOJ_17144_미세먼지안녕.java
@@ -1,0 +1,175 @@
+package 알고리즘연습.boj;
+
+import java.io.*;
+import java.util.StringTokenizer;
+
+public class BOJ_17144_미세먼지안녕 {
+    /**
+     * 실행시간 : 468 ms
+     *
+     * 메모리 : 38088 KB
+     *
+     * 시간복잡도 : O(T * R * C) ; 최대 250_000
+     */
+    static int R, C, T;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+        StringTokenizer st;
+
+        st = new StringTokenizer(br.readLine());
+        int r = Integer.parseInt(st.nextToken());
+        int c = Integer.parseInt(st.nextToken());
+        int t = Integer.parseInt(st.nextToken());
+
+        int[][] grid = new int[r][c];
+
+        for (int i = 0; i < r; i++) {
+            st = new StringTokenizer(br.readLine());
+            for (int j = 0; j < c; j++) {
+                grid[i][j] = Integer.parseInt(st.nextToken());
+            }
+        }
+
+        String ans = solution(r, c, t, grid);
+
+        bw.write(ans);
+
+        br.close();
+        bw.flush();
+        bw.close();
+    }
+
+    private static String solution(int r, int c, int t, int[][] grid) {
+        R = r;
+        C = c;
+        T = t;
+
+        int[] dy = {-1, 1, 0, 0};
+        int[] dx = {0, 0, -1, 1};
+
+
+        // 공기청정기 위치 저장
+        int upAcRow = -1;
+        int downAcRow = -1;
+        for (int i = 0; i < R; i++) {
+            for (int j = 0; j < C; j++) {
+                if (grid[i][j] == -1) {
+                    if (upAcRow == -1) {
+                        upAcRow = i;
+                    } else {
+                        downAcRow = i;
+                        break;
+                    }
+                }
+            }
+        }
+
+        int[][] temp;
+        for (int time = 0; time < T; time++) {
+            temp = new int[R][C];
+
+            // TODO 미세먼지 확산 : 연산이 동시에 일어나는 것을 구현해야 하므로 int[][] temp 활용
+            for (int y = 0; y < R; y++) {
+                for (int x = 0; x < C; x++) {
+                    if (grid[y][x] > 0) { // 미세먼지가 있다면
+                        int cnt = 0;
+                        for (int i = 0; i < 4; i++) {
+                            int ny = y + dy[i];
+                            int nx = x + dx[i];
+                            if (canSpread(ny, nx, grid)) { // 범위 밖이 아님 && 공기청정기 아님
+                                temp[ny][nx] += Math.floorDiv(grid[y][x], 5);
+                                cnt++;
+                            }
+                        }
+                        temp[y][x] += grid[y][x] - Math.floorDiv(grid[y][x], 5) * cnt;
+                    }
+                }
+            }
+
+            // TODO 공기청정기 작동
+            // 1. UP 공기청정기 배열회전
+
+            // 왼쪽면
+            for (int i = upAcRow - 1; i >= 1; i--) {
+                temp[i][0] = temp[i - 1][0];
+            }
+            // 위쪽면
+            for (int i = 0; i < C - 1; i++) {
+                temp[0][i] = temp[0][i + 1];
+            }
+
+            // 오른쪽면
+            for (int i = 0; i < upAcRow; i++) {
+                temp[i][C - 1] = temp[i + 1][C - 1];
+            }
+
+            // 아랫면 (공기청정기 전 2번째 칸까지 이동)
+            for (int i = C - 1; i >= 2; i--) {
+                temp[upAcRow][i] = temp[upAcRow][i - 1];
+            }
+
+            temp[upAcRow][0] = 0;
+            temp[upAcRow][1] = 0; // 공기청정기에서 나오는 바람은 깨끗한 바람
+
+            // 2. DOWN 공기청정기 배열회전
+
+            // 왼쪽면
+            for (int i = downAcRow + 1; i < R - 1; i++) {
+                temp[i][0] = temp[i + 1][0];
+            }
+
+            // 아랫면
+            for (int i = 0; i < C - 1; i++) {
+                temp[R - 1][i] = temp[R - 1][i + 1];
+            }
+
+            // 오른쪽면
+            for (int i = R - 1; i > downAcRow; i--) {
+                temp[i][C - 1] = temp[i - 1][C - 1];
+            }
+
+            // 윗면
+            for (int i = C - 1; i > 1; i--) {
+                temp[downAcRow][i] = temp[downAcRow][i - 1];
+            }
+
+            temp[downAcRow][0] = 0;
+            temp[downAcRow][1] = 0;
+
+            grid = temp;
+        }
+
+        int sum = 0;
+        for (int i = 0; i < R; i++) {
+            for (int j = 0; j < C; j++) {
+                sum += Math.max(grid[i][j], 0);
+            }
+        }
+
+        return String.valueOf(sum);
+    }
+
+    private static void testPrint(int[][] temp) {
+        for (int i = 0; i < R; i++) {
+            for (int j = 0; j < C; j++) {
+                System.out.print(temp[i][j] + " ");
+            }
+            System.out.println();
+        }
+        System.out.println("===============");
+    }
+
+    private static boolean canSpread(int y, int x, int[][] grid) {
+        return inRange(y, x) && !isAirCleaner(y, x, grid);
+    }
+
+    private static boolean inRange(int y, int x) {
+        return y >= 0 && y < R && x >= 0 && x < C;
+    }
+
+    private static boolean isAirCleaner(int y, int x, int[][] grid) {
+        return grid[y][x] == -1;
+    }
+}

--- a/Jecheol_Hwang/BOJ_1976_여행가자.java
+++ b/Jecheol_Hwang/BOJ_1976_여행가자.java
@@ -1,0 +1,87 @@
+package 알고리즘연습.boj;
+
+import java.io.*;
+import java.util.HashSet;
+import java.util.StringTokenizer;
+
+/**
+ * @algorithm union-find
+ * @time O(M * log N)
+ *
+ * N : 도시 개수 (200 이하)
+ * 길이 있을 수도, 없을 수도
+ *
+ * M : 여행 계획에 속한 도시들의 수 (1000 이하)
+ *
+ * 중간에 다른 도시를 경유해서 여행 가능
+ *
+ * 입력
+ * 1. N (도시의 수)
+ * 2. M (여행 계획에 속한 도시들의 수)
+ * 3. loop N (인접행렬)
+ *
+ * 출력
+ * -> 여행 계획이 가능한가? (어떻게든 연결되기만 하면 됨)
+ * 유니온파인드 해서 나중에 find 값을 hashset에 넣었는데 1이 되면 되는 것 아닌가?
+ */
+public class BOJ_1976_여행가자 {
+    private static int N, M;
+    private static int[] parent;
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+        StringTokenizer st;
+
+        N = Integer.parseInt(br.readLine());
+        M = Integer.parseInt(br.readLine());
+        parent = new int[N + 1];
+
+        /* root 노드 초기화 */
+        for (int i = 1; i <= N; i++) {
+            parent[i] = i;
+        }
+
+        /* 연결 노드 초기화 */
+        for (int i = 1; i <= N; i++) {
+            st = new StringTokenizer(br.readLine());
+            for (int j = 1; j <= N; j++) {
+                int num = Integer.parseInt(st.nextToken());
+                if (num == 1) {
+                    union(i, j);
+                }
+            }
+        }
+
+        st = new StringTokenizer(br.readLine());
+        HashSet<Integer> hs = new HashSet<>();
+        for (int i = 0; i < M; i++) {
+            int v = Integer.parseInt(st.nextToken());
+            hs.add(find(v));
+        }
+        bw.write(hs.size() == 1 ? "YES" : "NO");
+
+        br.close();
+        bw.flush();
+        bw.close();
+    }
+
+    private static void union(int u, int v) {
+        int uRoot = find(u);
+        int vRoot = find(v);
+        if (uRoot == vRoot) {
+            return;
+        }
+        if (uRoot < vRoot) {
+            parent[vRoot] = uRoot;
+        } else {
+            parent[uRoot] = vRoot;
+        }
+    }
+
+    private static int find(int v) {
+        if (parent[v] == v) {
+            return v;
+        }
+        return parent[v] = find(parent[v]);
+    }
+}

--- a/Jecheol_Hwang/BOJ_2110_공유기설치.java
+++ b/Jecheol_Hwang/BOJ_2110_공유기설치.java
@@ -1,0 +1,66 @@
+package 알고리즘연습.boj;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.StringTokenizer;
+
+/**
+ * @algorithm parametric search
+ * @time O(N * log N) ; 정렬 + 이분탐색 --> 320 ms
+ * @memory O(N) ; 정수배열 --> 29428 KB
+ *
+ * N : 집 개수
+ * C : 공유기 개수
+ */
+public class BOJ_2110_공유기설치 {
+    private static int N, C;
+    private static int[] arr;
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        N = Integer.parseInt(st.nextToken());
+        C = Integer.parseInt(st.nextToken());
+        arr = new int[N+1];
+        arr[0] = 0;
+
+        for (int i = 1; i <= N; i++) {
+            arr[i] = Integer.parseInt(br.readLine());
+        }
+        Arrays.sort(arr);
+
+        // 거리 이진탐색
+        int ans = binarySearch();
+        System.out.println(ans);
+    }
+
+    private static int binarySearch() {
+        int left = 0;
+        int right = arr[N];
+        int targetDist = 0; // "가장 인접한" 두 라우터 간 거리
+        int ansDist = 0;
+        while (left <= right) {
+            targetDist = (left + right) / 2;
+            long curDist = 0;
+            int routerCnt = 1; // 첫 번째 집에 설치하고 시작.
+            for (int i = 2; i <= N; i++) {
+                curDist += arr[i] - arr[i-1];
+                if (curDist >= targetDist) {
+                    curDist = 0;
+                    routerCnt++;
+                }
+            }
+
+            // 가능한 경우에는 더 늘려서 -> 최대가 되게
+            if (routerCnt >= C) {
+                left = targetDist + 1;
+                ansDist = Math.max(ansDist, targetDist); // 수정 부분
+            } else {
+                right = targetDist - 1;
+            }
+        }
+        return ansDist;
+    }
+
+}

--- a/Jecheol_Hwang/BOJ_21609_상어중학교.java
+++ b/Jecheol_Hwang/BOJ_21609_상어중학교.java
@@ -1,0 +1,237 @@
+package 알고리즘연습.boj;
+
+import java.io.*;
+import java.util.*;
+
+/**
+ * @algorithm simulation
+ * @time O(N^2) -> 196 ms
+ * @memory O(N^2) -> 16132 KB
+ */
+public class BOJ_21609_상어중학교 {
+    private static int N, M, ans;
+    private static int[][] map;
+    private static int[] dy = {1, -1, 0, 0};
+    private static int[] dx = {0, 0, 1, -1};
+    private static boolean[][] visited;
+    private static int rainbowCnt;
+    private static int groupSize;
+    private static final int BLANK = -2;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+        StringBuilder sb = new StringBuilder();
+        StringTokenizer st;
+
+        st = new StringTokenizer(br.readLine());
+        N = Integer.parseInt(st.nextToken());
+        M = Integer.parseInt(st.nextToken());
+        map = new int[N][N];
+
+        for (int i = 0; i < N; i++) {
+            st = new StringTokenizer(br.readLine());
+            for (int j = 0; j < N; j++) {
+                int num = Integer.parseInt(st.nextToken());
+                map[i][j] = num;
+            }
+        }
+
+        while (bomb()) {
+            gravity();
+            turnLeft();
+            gravity();
+        }
+
+        sb.append(ans);
+        bw.write(sb.toString());
+        br.close();
+        bw.flush();
+        bw.close();
+    }
+
+    /**
+     * 블록 그룹이 있는지 탐색
+     * -> 있으면, 가장 큰 블록 그룹을 터뜨림
+     */
+    private static boolean bomb() {
+        // 먼저 배열 순회하면서 블록 그룹 대표 블록을 물색 (우선순위큐 사용)
+        PriorityQueue<int[]> pq = new PriorityQueue<>((o1, o2) -> { // 대표 블록 담는 큐
+            if (o1[0] == o2[0]) {
+                return o1[1] - o2[1]; // 열 오름차순 (대표블록은 가장 작은 블록)
+            }
+            return o1[0] - o2[0]; // 행 오름차순
+        });
+
+        for (int i = 0; i < N; i++) {
+            for (int j = 0; j < N; j++) {
+                if (map[i][j] > 0) {
+                    pq.add(new int[]{i, j, map[i][j]}); // (y,x,block color)
+                }
+            }
+        }
+
+        // 폭파그룹 선택시 필요한 변수 선언 / 초기화
+        int bombGroupSize = -1;
+        int bombRainbowCnt = -1;
+        int bombY = -1;
+        int bombX = -1;
+        if (pq.isEmpty()) { // 만약 대표 블록이 될 일반 블록이 없는 경우는 -> 오토플레이 불가
+            return false;
+        }
+
+        visited = new boolean[N][N];
+        // PQ에서 하나씩 꺼내서 dfs 돌면서 (사이즈 + 무지개블록 개수) 카운트하고
+        while (!pq.isEmpty()) {
+            int[] bossBlock = pq.poll(); // 대표 블록 큐
+
+            int y = bossBlock[0];
+            int x = bossBlock[1];
+            int color = bossBlock[2];
+            initRainbowVisit();
+
+            // 해당 블록이 탐색 가능하면 -> 탐색 시작
+            if (!visited[y][x]) {
+                rainbowCnt = 0;
+                groupSize = 0;
+                visited[y][x] = true;
+                dfs(y, x, color);
+
+                // 매번 비교하면서 폭파할 블록 선택 (대표블록 y, x 저장/갱신)
+                // 필요시 폭파대상그룹 갱신
+                if (groupSize > bombGroupSize) { // 이번에 탐색한 그룹이 더 크면
+                    bombGroupSize = groupSize;
+                    bombRainbowCnt = rainbowCnt;
+                    bombY = y;
+                    bombX = x;
+                } else if (groupSize == bombGroupSize) { // 만약 사이즈가 같으면
+                    if (rainbowCnt > bombRainbowCnt) { // 무지개블록 개수가 더 많으면
+                        bombGroupSize = groupSize;
+                        bombRainbowCnt = rainbowCnt;
+                        bombY = y;
+                        bombX = x;
+                    } else if (rainbowCnt == bombRainbowCnt) { // 무지개블록 개수도 같으면
+                        if (bombY < y) {
+                            bombGroupSize = groupSize;
+                            bombRainbowCnt = rainbowCnt;
+                            bombY = y;
+                            bombX = x;
+                        } else if (bombY == y) {
+                            if (bombX < x) {
+                                bombGroupSize = groupSize;
+                                bombRainbowCnt = rainbowCnt;
+                                bombY = y;
+                                bombX = x;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        if (bombGroupSize < 2) { // 사이즈가 2가 안되면 stop
+            return false;
+        }
+        // 폭파할 블록의 대표블록을 기준으로 dfs 돌면서 폭파 (바로 map에 업데이트)
+        visited = new boolean[N][N];
+        if (bombY != -1 && bombX != -1) {
+            groupSize = 0;
+            visited[bombY][bombX] = true;
+            exec(bombY, bombX, map[bombY][bombX]);
+        }
+        ans += (int) Math.pow(groupSize, 2);
+        return true;
+    }
+
+    private static void exec(int y, int x, int color) {
+        map[y][x] = BLANK;
+        groupSize++;
+        for (int i = 0; i < 4; i++) {
+            int ny = y + dy[i];
+            int nx = x + dx[i];
+            if (canGo(ny, nx, color)) {
+                visited[ny][nx] = true;
+                exec(ny, nx, color);
+            }
+        }
+    }
+
+    private static void dfs(int y, int x, int color) {
+        groupSize++;
+        for (int i = 0; i < 4; i++) {
+            int ny = y + dy[i];
+            int nx = x + dx[i];
+            if (canGo(ny, nx, color)) {
+                if (map[ny][nx] == 0) { // 만약 탐색대상이 rainbow블록이면
+                    rainbowCnt++;
+                }
+                visited[ny][nx] = true;
+                dfs(ny, nx, color);
+            }
+        }
+    }
+
+    private static void initRainbowVisit() {
+        for (int i = 0; i < N; i++) {
+            for (int j = 0; j < N; j++) {
+                if (map[i][j] == 0) {
+                    visited[i][j] = false;
+                }
+            }
+        }
+    }
+
+    /**
+     * 배열에 중력을 적용
+     */
+    private static void gravity() {
+        int[] temp = new int[N];
+
+        for (int x = 0; x < N; x++) {
+            int gravityIdx = 0;
+            Arrays.fill(temp, BLANK);
+            for (int y = N - 1; y >= 0; y--) {
+                if (map[y][x] == BLANK) {
+                    continue;
+
+                    // 만약 검정 블록을 만나면, gravityIdx를 검정 블록 위치로 갱신하고 그 자리에 입력
+                } else if (map[y][x] == -1) {
+                    gravityIdx = N - y - 1;
+                }
+                temp[gravityIdx++] = map[y][x];
+            }
+            // 중력 적용상황 업데이트
+            for (int i = 0; i < N; i++) {
+                map[N - i - 1][x] = temp[i];
+            }
+
+        }
+    }
+
+    /**
+     * 배열을 반시계 방향으로 90도 회전시킴
+     */
+    private static void turnLeft() {
+        // 단순함. y가 x로 되면 됨.
+        int[][] temp = new int[N][N];
+        for (int i = 0; i < N; i++) {
+            for (int j = 0; j < N; j++) {
+                temp[N - j - 1][i] = map[i][j];
+            }
+        }
+        for (int i = 0; i < N; i++) {
+            map[i] = temp[i].clone();
+        }
+    }
+
+    private static boolean inRange(int y, int x) {
+        return y >= 0 && y < N && x >= 0 && x < N;
+    }
+
+    private static boolean canGo(int y, int x, int blockType) {
+        return inRange(y, x) && canGoBlock(y, x, blockType);
+    }
+
+    private static boolean canGoBlock(int y, int x, int blockType) {
+        return map[y][x] != -1 && ((map[y][x] == 0 || map[y][x] == blockType) && !visited[y][x]); // 방문X면서 색깔이 같거나 or 무지개블록이거나
+    }
+}

--- a/Jecheol_Hwang/BOJ_23796_2147483648게임.java
+++ b/Jecheol_Hwang/BOJ_23796_2147483648게임.java
@@ -1,0 +1,122 @@
+package 알고리즘연습.boj;
+
+import java.io.*;
+import java.util.*;
+
+/**
+ * @intuition 그냥 중력 시뮬 문제 + 중복 체크
+ * @algorithm 시뮬레이션
+ * @time O(N^2) -> 124 ms
+ * @memory O(N^2) -> 14252 KB
+ */
+public class BOJ_23796_2147483648게임 {
+    private static long[][] map;
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+        StringBuilder sb = new StringBuilder();
+        StringTokenizer st;
+        map = new long[8][8];
+
+        for (int i = 0; i < 8; i++) {
+            st = new StringTokenizer(br.readLine());
+            for (int j = 0; j < 8; j++) {
+                map[i][j] = Integer.parseInt(st.nextToken());
+            }
+        }
+        String cmd = br.readLine();
+        go(cmd);
+
+        for (int i = 0; i < 8; i++) {
+            for (int j = 0; j < 8; j++) {
+                sb.append(map[i][j] % (long) 1e10 + " ");
+            }
+            sb.append("\n");
+        }
+        bw.write(sb.toString());
+        br.close();
+        bw.flush();
+        bw.close();
+    }
+
+    private static void go(String cmd) {
+        long[] temp;
+        int tdx;
+        if (cmd.equals("R")) { // RIGHT
+            for (int i = 0; i < 8; i++) {
+                temp = new long[8];
+                tdx = 0;
+                for (int j = 7; j >= 0; j--) {
+                    if (map[i][j] > 0) {
+                        // collapse 되는 숫자가 있는 경우
+                        if (tdx > 0 && temp[tdx - 1] == map[i][j]) {
+                            tdx--;
+                            temp[tdx++] += map[i][j] + (long) 1e10;
+                            continue;
+                        }
+                        temp[tdx++] = map[i][j];
+                    }
+                }
+                // 커밋
+                for (int j = 0; j < 8; j++) {
+                    map[i][7-j] = temp[j] % (long) 1e10;
+                }
+            }
+        } else if (cmd.equals("L")) { // LEFT
+            for (int i = 0; i < 8; i++) {
+                temp = new long[8];
+                tdx = 0;
+                for (int j = 0; j < 8; j++) {
+                    if (map[i][j] > 0) {
+                        if (tdx > 0 && temp[tdx - 1] == map[i][j]) {
+                            tdx--;
+                            temp[tdx++] += map[i][j] + (long) 1e10;
+                            continue;
+                        }
+                        temp[tdx++] = map[i][j];
+                    }
+                }
+                for (int j = 0; j < 8; j++) {
+                    map[i][j] = temp[j] % (long) 1e10;
+                }
+            }
+        } else if (cmd.equals("U")) { // UP
+            for (int j = 0; j < 8; j++) {
+                temp = new long[8];
+                tdx = 0;
+                for (int i = 0; i < 8; i++) {
+                    if (map[i][j] > 0) {
+                        if (tdx > 0 && temp[tdx - 1] == map[i][j]) {
+                            tdx--;
+                            temp[tdx++] += map[i][j] + (long) 1e10;
+                            continue;
+                        }
+                        temp[tdx++] = map[i][j];
+                    }
+                }
+                for (int i = 0; i < 8; i++) {
+                    map[i][j] = temp[i] % (long) 1e10;
+                }
+            }
+        } else if (cmd.equals("D")) {
+            for (int j = 0; j < 8; j++) {
+                temp = new long[8];
+                tdx = 0;
+                for (int i = 7; i >= 0; i--) {
+                    if (map[i][j] > 0) {
+                        if (tdx > 0 && temp[tdx - 1] == map[i][j]) {
+                            tdx--;
+                            temp[tdx++] += map[i][j] + (long) 1e10;
+                            continue;
+                        }
+                        temp[tdx++] = map[i][j];
+                    }
+                }
+                for (int i = 7; i >= 0; i--) {
+                    map[i][j] = temp[7-i] % (long) 1e10;
+                }
+            }
+        }
+
+    }
+}

--- a/Jecheol_Hwang/BOJ_2447_별찍기10.java
+++ b/Jecheol_Hwang/BOJ_2447_별찍기10.java
@@ -1,0 +1,42 @@
+package 알고리즘연습.boj;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+/**
+ * 분할정복 문제
+ */
+public class BOJ_2447_별찍기10 {
+    private static StringBuffer sb;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int n = Integer.parseInt(br.readLine());
+        sb = new StringBuffer();
+        for (int i = 1; i <= n; i++) {
+            for (int j = 1; j <= n; j++) {
+                go(i, j, n);
+            }
+            sb.append("\n");
+        }
+        System.out.println(sb.toString());
+    }
+
+    private static void go(int r, int c, int n) {
+        int first = n / 3;
+        int second = n / 3 * 2;
+        int nn = n / 3;
+
+        if (r > first && r <= second && c > first && c <= second) {
+            sb.append(" ");
+        } else {
+            if (n / 3 == 1) {
+
+                sb.append("*");
+                return;
+            }
+            go(r % nn, c % nn, nn);
+        }
+    }
+}

--- a/Jecheol_Hwang/BOJ_2565_전깃줄.java
+++ b/Jecheol_Hwang/BOJ_2565_전깃줄.java
@@ -1,0 +1,65 @@
+package 알고리즘연습.boj;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.StringTokenizer;
+
+/**
+ * 왼쪽 줄을 기준으로 정렬하여 오른쪽 숫자를 보았을 때,
+ * 가장 긴 증가 부분 수열을 구성하면 답이 됨.
+ *
+ * dp[i] : i번째 숫자까지 봤을 때 가장 긴 증가 부분 수열의 길이
+ */
+public class BOJ_2565_전깃줄 {
+    private static int[] dp;
+    private static int N;
+    private static int[][] arr;
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+        N = Integer.parseInt(br.readLine());
+        dp = new int[N + 1];
+        arr = new int[N + 1][2];
+
+        for (int i = 1; i <= N; i++) {
+            st = new StringTokenizer(br.readLine());
+            arr[i][0] = Integer.parseInt(st.nextToken());
+            arr[i][1] = Integer.parseInt(st.nextToken());
+
+        }
+        Arrays.sort(arr, Comparator.comparingInt(o -> o[0]));
+
+        dp[0] = 0;
+        for (int i = 1; i <= N; i++) {
+            dp[i] = 1; // 모든 항이 최소 스스로까지 최장 증가 부분 수열임.
+        }
+
+        go(N);
+        int res = 0;
+        for (int i = 0; i <= N; i++) {
+            res = Math.max(res, dp[i]);
+        }
+        System.out.println(N - res);
+
+    }
+
+    private static int go(int n) {
+        // 느낌대로 잡아가자면
+        // 최장 증가 부분 수열을 구하려면
+        // 중복 숫자가 없으니까 차근차근 진행해도 되고
+        // 오름차순을 구성할 수 있을 때,
+        // dp 값 갱신
+        for (int i = 2; i <= N; i++) {
+            for (int j = 1; j < i; j++) {
+                if (arr[i][1] > arr[j][1]) {
+                    dp[i] = Math.max(dp[i], dp[j] + 1);
+                }
+            }
+        }
+        return dp[n];
+    }
+}

--- a/Jecheol_Hwang/BOJ_2583_영역구하기.java
+++ b/Jecheol_Hwang/BOJ_2583_영역구하기.java
@@ -1,0 +1,125 @@
+package 알고리즘연습.boj;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayDeque;
+import java.util.PriorityQueue;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
+public class BOJ_2583_영역구하기 {
+    private static int m,n;
+    private static int[][] grid;
+    private static boolean[][] visited;
+    private static int area;
+    private static int partition;
+    private static Queue<int[]> q = new ArrayDeque<>();
+    private static Queue<Integer> pq = new PriorityQueue<>();
+    public static void main(String[] args) throws IOException {
+        /*
+        * INPUT :
+        * m : height
+        * n : width
+        * k : 직사각형 개수
+        * (모두 100 이하의 자연수)
+        *
+        * loop k :
+        *   직사각형의 왼쪽 아래 꼭짓점 y,x 좌표값과 오른쪽 위 꼭짓점의 y,x 좌표값이 빈칸을 사이에 두고 주어짐
+        *
+        * 모눈종이의 왼쪽 아래 꼭짓점의 좌표는 (0,0) - 오른쪽 위 꼭짓점의 좌표는 (N,M)
+        *
+        * 입력되는 k개의 직사각형들이 모눈종이 전체를 채우는 경우는 없다.
+        *
+        * OUTPUT :
+        * 1) 분리되어 나눠지는 영역의 개수를 출력
+        * 2) 각 영역의 넓이를 오름차순으로 정렬하여 빈칸을 사이에 두고 출력 (오름차순 정렬)
+        * */
+
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        m = Integer.parseInt(st.nextToken());
+        n = Integer.parseInt(st.nextToken());
+        int k = Integer.parseInt(st.nextToken());
+        grid = new int[m + 1][n + 1];
+        visited = new boolean[m + 1][n + 1];
+
+        for (int i = 0; i < k; i++) {
+            st = new StringTokenizer(br.readLine());
+            int x1 = Integer.parseInt(st.nextToken());
+            int y1 = Integer.parseInt(st.nextToken());
+            int x2 = Integer.parseInt(st.nextToken());
+            int y2 = Integer.parseInt(st.nextToken());
+
+            for (int j = y1 + 1; j <= y2; j++) {
+                for (int l = x1 + 1; l <= x2; l++) {
+                    grid[j][l] = -1;
+                }
+            }
+        }
+        for (int i = 0; i <= m; i++) {
+            grid[i][0] = -1;
+            visited[i][0] = true;
+        }
+        for (int i = 0; i <= n; i++) {
+            grid[0][i] = -1;
+            visited[0][i] = true;
+        }
+//        for (int i = 0; i <= m; i++) {
+//            for (int j = 0; j <= n; j++) {
+//                System.out.print(grid[i][j] + " ");
+//            }
+//            System.out.println();
+//        }
+
+        for (int i = 1; i <= m; i++) {
+            for (int j = 1; j <= n; j++) {
+                if (grid[i][j] == 0) {
+                    q.add(new int[]{i, j});
+                }
+            }
+        }
+
+        bfs();
+        System.out.println(partition);
+        while (!pq.isEmpty()) {
+            System.out.print(pq.poll() + " ");
+        }
+    }
+    private static void bfs() {
+        while (!q.isEmpty()) {
+            int[] now = q.poll();
+            int y = now[0];
+            int x = now[1];
+            if (canGo(y, x)) {
+//                System.out.println(y + " " + x);
+                area = 0;
+                partition++;
+                dfs(y, x);
+                pq.add(area);
+            }
+        }
+    }
+
+    private static void dfs(int y, int x) {
+        int[] dy = {0, 0, -1, 1};
+        int[] dx = {1, -1, 0, 0};
+        area++;
+        visited[y][x] = true;
+        for (int i = 0; i < 4; i++) {
+            int ny = y + dy[i];
+            int nx = x + dx[i];
+            if (canGo(ny, nx)) {
+                dfs(ny, nx);
+            }
+        }
+    }
+
+    private static boolean canGo(int y, int x) {
+        return inRange(y, x) && grid[y][x] == 0 && !visited[y][x];
+    }
+
+    private static boolean inRange(int y, int x) {
+        return y >= 1 && y <= m && x >= 1 && x <= n;
+    }
+}

--- a/Jecheol_Hwang/BOJ_2705_팰린드롬파티션.java
+++ b/Jecheol_Hwang/BOJ_2705_팰린드롬파티션.java
@@ -1,0 +1,35 @@
+package 알고리즘연습.boj;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+public class BOJ_2705_팰린드롬파티션 {
+    public static void main(String[] args) throws IOException {
+        int[] dp = new int[1001];
+        dp[0] = 1;
+        dp[1] = 1;
+        for (int i = 2; i <= 1000; i++) {
+            dp[i] = 1; // 기본 초기화
+            if (i % 2 == 0) { // 짝수면
+                dp[i] += dp[i / 2];
+            }
+            int mid = i;
+            while (mid - 2 > 0) {
+                mid -= 2;
+                dp[i] += dp[(i - mid) / 2];
+            }
+        }
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int T = Integer.parseInt(br.readLine());
+        StringBuffer sb = new StringBuffer();
+        for (int i = 0; i < T; i++) {
+            int n = Integer.parseInt(br.readLine());
+            sb.append(dp[n]).append("\n");
+        }
+        System.out.println(sb.toString());
+    }
+
+
+
+}

--- a/Jecheol_Hwang/BOJ_31235_올라올라.java
+++ b/Jecheol_Hwang/BOJ_31235_올라올라.java
@@ -1,0 +1,43 @@
+package 알고리즘연습.boj;
+
+import java.io.*;
+import java.util.StringTokenizer;
+
+/**
+ * @intuition 각 elem에 대한 최대값 갱신에 필요한 최대 index 수를 계산하면 될 것으로 봤다.
+ * 즉, 매 elem을 받고 비교 연산을 통해 최대 index 길이를 greedy하게 갱신하면 되는 문제이다.
+ *
+ * @algorithm greedy
+ * @time O(N) -> 500 ms
+ * @memory O(1) -> 115436 KB
+ */
+public class BOJ_31235_올라올라 {
+    private static int N;
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+        StringTokenizer st;
+
+        N = Integer.parseInt(br.readLine());
+        st = new StringTokenizer(br.readLine());
+        int cnt = 1;
+        int k = 0;
+        int prevMax = 0;
+        int num = 0;
+        for (int i = 0; i < N; i++) {
+            num = Integer.parseInt(st.nextToken());
+            if (num < prevMax) {
+                cnt++;
+            } else {
+                prevMax = num;
+                k = Math.max(k, cnt);
+                cnt = 1;
+            }
+        }
+        k = Math.max(k, cnt);
+        bw.write(String.valueOf(k));
+        br.close();
+        bw.flush();
+        bw.close();
+    }
+}


### PR DESCRIPTION
자꾸 PR 머지를 안해서 겹치게 올리게 되네요ㅠㅠ

# 🔢 2,147,483,648 게임
### 🤔 INTUITION
그냥 중력 시뮬 문제로 이해했습니다. 다만, 합쳐진 숫자였는지 여부 체크를 곁들인

중력 적용 중 숫자가 동일할 경우 merge 연산이 수행되어야 하는데, 이게 연속적으로 발생할 수 없다는 게 이 문제의 유일한 포인트로 보였습니다. merge 연산 여부를 체크하는 걸 어떻게 할까 하다가, 저는 int 범위 이상의 숫자를 merge 연산 결과에 더해줘서 그 이후로는 이 숫자가 그 어떤 숫자와도 일치하지 않도록 해서 중복 연산되지 않도록 처리해 줬습니다. 이는 다시 배열을 업데이트 할 때 mod 연산으로 제거해 줬습니다.

### ✅ ALGORITHM
1. map을 저장합니다.
2. `int[] temp` 를 이용하여 한 줄 한 줄 중력을 적용해 줍니다. 만약, 숫자가 합쳐지는 경우에는 10^10 제곱을 더해줘서 다시는 합쳐질 수 없게 처리했습니다. 이후 중력 적용이 끝난 뒤에 배열 업데이트 시 10^10 제곱으로 mod 연산을 해줘서 연산 여부를 초기화해줬습니다.

# 🎈 BOJ 14500 테트로미노
### 🤔 INTUITION
정답률이 낮아서 좀 쫄긴 했는데, 딱 봤을 떄 500 by 500 좌표 기준으로 깊이 4의 백트래킹으로 숫자 구하는 게 가능하겠다 싶었습니다. 여기서 `ㅗ` 모양 블록을 탐색할 수 없다는 걸 처음에는 놓쳤는데, 이를 추가해주니 문제 없이 풀어낼 수 있었습니다.

### ✅ ALGORITHM
1. map을 저장해 둡니다.
3. 각 맵의 좌표를 시작점으로 삼아서 dfs 탐색 + 볼록블록 별도 탐색을 진행합니다.


# 🆙 BOJ 31235 올라올라
### 🤔 INTUITION
직관적으로 N의 크기를 고려하지 않고 문제를 봤을 때에 k 값에 따라 N개의 숫자 중 최대값이 증가 수열을 이루는지를 판단하면 되는 거라 생각했습니다.

근데 이렇게 하면 O(N^2) 연산을 해야 하므로, 연산량을 줄이기 위해 기존 비교연산값을 저장하여 활용하는 DP 알고리즘을 사용하면 되려나? 했습니다. 하지만, 제가 떠올린 DP 배열로 운영하기엔 2차원 배열로 저장하려고 헀어서 메모리 초과가 날 것으로 봤습니다.

더욱 최적화가 필요할 것으로 봤는데, 곰곰히 생각해보니 결국 **주어진 수열을 순회하면서 elem의 최대값이 갱신되는 주기를 카운트하여, 최대 갱신 주기를 찾아내면 그게 반드시 답이 될 수 있는 구조**라서 greedy로 답을 도출하면 될 것으로 판단했습니다.

### ✅ ALGORITHM
감소하지 않는 수열이라는 건, 크거나 '같은' 수열을 구성하는 걸 의미하므로, 다음 elem이 이전 숫자보다 '더 작은' 경우만 카운트하면 됩니다.

1. elem을 입력받습니다.
4. 이전까지의 max value(초기값 0)와 비교합니다.
5. max value가 갱신되는 경우에는 k와 cnt를 비교하여 최대값을 k로 갱신합니다. 이후 cnt를 1로 초기화합니다.
6. 만약 max value가 갱신되지 않는 경우에는 cnt를 증가시킵니다.
7. 연산이 모두 끝난 뒤, k값을 출력합니다.

위 논리에서 elem 순회 시 최대의 cnt 값이 반드시 정답인 K가 되므로 그리디 알고리즘으로 판단했습니다.


# 🦈 BOJ 21609 상어중학교
### 🤔 INTUITION
N이 작은 걸로 봐서 냅다 무지성 시뮬을 돌려도 문제 없겠다고 나름 판단을 하고 무지성 배열생성 + 무지성 N^2 탐색 반복을 이용해 풀었습니다. 저는 뚝딱뚝딱 최적화된 로직을 바로 생성하기에 아직은 연습이 더 필요하다고 느껴서ㅜ 일단 많은 조건을 준수하면서 요구사항을 구현하는 것에 중점을 두었습니다...

### ✅ ALGORITHM
대부분 그렇게 하셨겠지만, 블록그룹 찾는 로직, 터뜨리는 로직, 중력 적용 로직, 배열돌리기 로직을 각각 함수화해서 정리했습니다. 블록 그룹 탐색시 인근 노드 크기 출력은 DFS가 더 편하다고 개인적으로 생각해서, DFS를 이용하여 각 블록 그룹을 찾아줬습니다.

1. 우선순위 큐를 이용하여 배열 상의 일반 블록 위치를 y,x값의 오름차순으로 관리 (대장 블록 위치)
8. 우선순위 큐에서 뽑아낸 대장 블록을 기준으로 블록 그룹 사이즈 조사 (DFS 이용)
9. 블록 그룹 사이즈가 2 이상인 경우 (터뜨릴 수 있는 경우), 블록 그룹 사이즈 & 무지개블록 개수 & 대장블록 좌표를 저장해 두었습니다. 갱신이 필요하면 갱신해 주었습니다.
10. 폭파할만한 블록 그룹이 있으면 파괴해주고, 중력 + 배열돌리기 + 중력 해줬습니다.

### ⏳ 풀이를 구성하는 시간이 오래 걸린 이유
이 문제는 다른 것 보다는 "무지개 블록은 중복으로 먹을 수 있다"라는 조건을 캐치하는 게 중요했던 것 같은데, 운이 좋게도 이는 빨리 떠올랐지만 대장 블록들 좌표 비교 로직에서 제가 부등호를 반대로 설정해두었는데, 운이 나쁘게도 TC가 통과되어 뭐가 문제인지 찾는 데에 한참 걸렸습니다ㅠ 나중에 곰곰히 한줄한줄 뜯어보다가 그제서야 알아내고 저는 그만 울어버렸습니다 😭 

### 🙇 커밋이 밀린 건에 대한 변명
종종 실력 부족 이슈로 풀지 못하여 문제가 조금씩 밀리게 되느라 PR을 미루게 되었는데요... 뭔가 아예 모르겠으면 답을 참고하겠지만 전반적으로 알듯말듯 인 문제들이 빠르게 안풀려서 커밋이 지체되었네요ㅜㅠㅠ

수창이의 숫자타자대회 제외하고 누적 커밋 제출합니다

숫자타자대회도 포기않고 꼭 풀어서 올게용...!
