### PR TITLE
[BOJ]31235/골드4/448ms/2h/백승헌

### DIFF
--- a/SeungHun Baek/BOJ_31235_올라올라.java
+++ b/SeungHun Baek/BOJ_31235_올라올라.java
@@ -1,0 +1,32 @@
+import java.util.*;
+import java.io.*;
+
+public class BOJ_31235_올라올라 {
+    
+    static int N;
+    static StringTokenizer st;
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    
+    public static void main(String[] args) throws IOException {
+        N = Integer.parseInt(br.readLine());
+        int c = 1;
+        int l = 1;
+
+        st = new StringTokenizer(br.readLine());
+        int p = Integer.parseInt(st.nextToken());
+
+        for (int i = 1; i < N; i++) {
+            int next = Integer.parseInt(st.nextToken());
+
+            if (p > next) {
+                l++;
+            } else {
+                c = Math.max(c, l);
+                l = 1;
+                p = next;
+            }
+        }
+
+        System.out.println(Math.max(c, l));
+    }
+}


### PR DESCRIPTION
dp? 슬라이드 윈도우? 이분탐색? 고민하다가 
이분탐색으로 풀었는데 역시나 시간초과...

해당 수열이 성립하기 위해서는 
특정 인덱스의 원소가 이전의 최댓값보다 
크거나 같은 수를 포함하는 범위를 가져야 한다는 사실을 깨달았다...

ex)

5 6 7 **3** 1 1 1 1 1 1 1 1 **7** 7
...........^.............................. ^...

증가하는 수열이 성립하기 위해서는 4번째 인덱스의 원소인 **3**이 이전의 최댓값인 **7**보다 크거나 같은 값을 포함하는 범위에 놓여야하므로 K의 최솟값은 **10**

