### PR TITLE
[BOJ]31235/골드4/456ms/50m/신권일

### DIFF
--- a/Gwonil_Shin/BOJ_31235_올라올라.java
+++ b/Gwonil_Shin/BOJ_31235_올라올라.java
@@ -1,0 +1,38 @@
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class Main {
+    static int N;
+    static int []arr;
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+        N = Integer.parseInt(br.readLine());
+        arr=new int[N];
+
+        st=new StringTokenizer(br.readLine());
+
+        for(int i=0;i<N;i++){
+            arr[i]=Integer.parseInt(st.nextToken());
+        }
+
+        int start=0;
+        int size=1;
+
+        for(int i=1;i<N;i++){
+            if(arr[start]>arr[i]){
+                if(i==N-1){
+                    size=Math.max(N-start,size);
+                }
+                continue;
+            }
+
+            size=Math.max(i-start,size);
+            start=i;
+        }
+
+
+        System.out.println(size);
+    }
+}


### PR DESCRIPTION
투포인터 비스무리하게 푼 문제였습니다.
근데 백준 분류를 보니 그리디로 적혀있어서 왜 그리디인지 잘 모르겠는..

# 풀이 과정

처음에는 당연하게 N과 제한 시간을 봤습니다. (N=100만, 시간=0.7초 ->7000만회)

size 1짜리를 입력으로 체크하고 이후 size 2부터 size 칸씩 뛰면서 최대값을 확인하는 로직을 생각해봤는데
어차피  N짜리의 배열을 size 1~N까지 계속 보는거라 시간복잡도는 O(N^2)이라 시간 초과가 뜰게 명확했습니다.

따라서 적은 탐색으로 처리할수 있어야 했죠

이런 형식의 문제는 대부분 한번의 탐색으로 끝낼수 있다는게 느낌으로 왔고 그래서 생각해 낸것이 투포인터 였습니다.
여기까지는 금방 떠올렸는데 로직을 확실히 만들고 이를 코드로 옮기는데 상당히 오랜 시간이 걸렸네요

# 로직
시작 인덱스(0)을 잡아두고
해당 인덱스의 값보다 이후의 배열의 값이 작은 경우는 크기를 늘리는것으로 커버가 가능하다는 생각으로 넘어가고
이후 배열의 값이 크거나 같은 경우는 여태까지 pass한 것의 크기가 시작 인덱스가 커버할수 있는 최소의 k라고 볼수 있습니다.
이런 식으로 k가 가능한 곳을 여러개 찾아서 이에 대한 최대의 k가 우리가 원하는 값이라고 할수 있습니다.

ex) 
3 1 4 2 5
의 경우는 index 0이 커버할수 있는 최소 범위는 3 1 이렇게 2 입니다. 이후 4는 4와 2와 5 는 자기자신 자기 자신이 최소한이라고 볼수 있기에
최종적으로 전체 배열에서는 k=2가 최소한의 값이라고 볼수 있겠습니다.
즉 start 인덱스의 위치를 기준으로 작은 크기를 찾는 것이라고 볼수 있겠네요.


PS. 
글로 설명하려니까 매우 어렵네요... 생각한것을 글로 정리하는 연습을 해야할거 같습니다...! 
