### PR TITLE
[BOJ]1911/골드5/260ms/1시간/황제철

### DIFF
--- a/Jecheol_Hwang/BOJ_1911_흙길보수하기.java
+++ b/Jecheol_Hwang/BOJ_1911_흙길보수하기.java
@@ -23,12 +23,12 @@ import java.util.*;
  * -> 시작점 기준으로 그리디하게 배치하면 될듯.
  *
  * @algorithm 그리디
- * @time O(N) -> 260 ms
+ * @time O(N * log N) -> 260 ms
  * @memory O(N) -> 20876 KB
  */
 public class BOJ_1911_흙길보수하기 {
     private static int N, L;
-    private static long[][] arr;
+    private static int[][] arr;
     private static long ans;
     public static void main(String[] args) throws IOException {
         BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
@@ -39,7 +39,7 @@ public class BOJ_1911_흙길보수하기 {
         st = new StringTokenizer(br.readLine());
         N = Integer.parseInt(st.nextToken());
         L = Integer.parseInt(st.nextToken());
-        arr = new long[N][2];
+        arr = new int[N][2];
 
         for (int i = 0; i < N; i++) {
             st = new StringTokenizer(br.readLine());
@@ -51,7 +51,7 @@ public class BOJ_1911_흙길보수하기 {
         Arrays.sort(arr, Comparator.comparingLong(o -> o[0]));
 
         long lastIdx = 0; // 널빤지를 마지막으로 둔 위치
-        for (long[] ptr : arr) {
+        for (int[] ptr : arr) {
             // 웅덩이 좌표 [s,e)
             long s = ptr[0];
             long e = ptr[1];

--- a/Jecheol_Hwang/BOJ_1911_흙길보수하기.java
+++ b/Jecheol_Hwang/BOJ_1911_흙길보수하기.java
@@ -50,21 +50,21 @@ public class BOJ_1911_흙길보수하기 {
         // 그리디를 위한 정렬
         Arrays.sort(arr, Comparator.comparingLong(o -> o[0]));
 
-        long lastIdx = 0; // 널빤지를 마지막으로 둔 위치
+        int lastIdx = 0; // 널빤지를 마지막으로 둔 위치
         for (int[] ptr : arr) {
             // 웅덩이 좌표 [s,e)
-            long s = ptr[0];
-            long e = ptr[1];
+            int s = ptr[0];
+            int e = ptr[1];
 
             // 다시 차곡차곡 쌓으면 되는 경우
             if (s >= lastIdx) {
 //                System.out.println("=========s >= lastIdx============");
                 lastIdx = s;
-                long length = e - s;
+                int length = e - s;
 //                System.out.println("length = " + length);
-                long share = length / L;
+                int share = length / L;
 //                System.out.println("share = " + share);
-                long remainder = length % L;
+                int remainder = length % L;
 //                System.out.println("remainder = " + remainder);
                 ans += share + (remainder > 0 ? 1 : 0); // 널빤지 개수 추가
 //                System.out.println("ans = " + ans);
@@ -72,11 +72,11 @@ public class BOJ_1911_흙길보수하기 {
 //                System.out.println("lastIdx = " + lastIdx);
             } else if (lastIdx < e) { // 중간에 마무리가 된 상태에서 널빤지를 더 깔아야 하는 상황인 경우
 //                System.out.println("=========lastIdx < e============");
-                long length = e - lastIdx;
+                int length = e - lastIdx;
 //                System.out.println("length = " + length);
-                long share = length / L;
+                int share = length / L;
 //                System.out.println("share = " + share);
-                long remainder = length % L;
+                int remainder = length % L;
 //                System.out.println("remainder = " + remainder);
                 ans += share + (remainder > 0 ? 1 : 0); // 널빤지 개수 추가
 //                System.out.println("ans = " + ans);

--- a/Jecheol_Hwang/BOJ_1911_흙길보수하기.java
+++ b/Jecheol_Hwang/BOJ_1911_흙길보수하기.java
@@ -1,0 +1,93 @@
+package 알고리즘연습.boj;
+
+import java.io.*;
+import java.util.*;
+
+/**
+ * N : 물웅덩이 개수 (1 이상 10,000 이하)
+ * L : 널빤지 길이 (1 이상 1백만 이하)
+ *
+ * 웅덩이 위치는 0 이상 1십억 이하 정수 (겹치지 않음)
+ *
+ * 물웅덩이를 모두 덮기 위해 필요한 널빤지의 최소 개수
+ *
+ * @intuition 그리디/Meeting-room-problem과 유사해보임.
+ * 웅덩이 시작 좌표와 끝 좌표를 long[] 으로 저장해두고
+ *
+ * 시작 좌표를 기준으로 배치한다면?
+ * 이게 최소가 되는지 아닌지만 판별하면 됨 (예외가 있나?)
+ * -> 0 1 1 1 2 2 2 0 3 3 3 4 4 4
+ *
+ * 널빤지를 최소로 깔아야 하니까 최대한 길게 배치하는게 좋고,
+ * 근데 또 전 범위를 커버해야 하는 건 맞으니까 시작점을 간과할 수 없음
+ * -> 시작점 기준으로 그리디하게 배치하면 될듯.
+ *
+ * @algorithm 그리디
+ * @time O(N) -> 260 ms
+ * @memory O(N) -> 20876 KB
+ */
+public class BOJ_1911_흙길보수하기 {
+    private static int N, L;
+    private static long[][] arr;
+    private static long ans;
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+        StringBuilder sb = new StringBuilder();
+        StringTokenizer st;
+
+        st = new StringTokenizer(br.readLine());
+        N = Integer.parseInt(st.nextToken());
+        L = Integer.parseInt(st.nextToken());
+        arr = new long[N][2];
+
+        for (int i = 0; i < N; i++) {
+            st = new StringTokenizer(br.readLine());
+            arr[i][0] = Integer.parseInt(st.nextToken());
+            arr[i][1] = Integer.parseInt(st.nextToken());
+        }
+
+        // 그리디를 위한 정렬
+        Arrays.sort(arr, Comparator.comparingLong(o -> o[0]));
+
+        long lastIdx = 0; // 널빤지를 마지막으로 둔 위치
+        for (long[] ptr : arr) {
+            // 웅덩이 좌표 [s,e)
+            long s = ptr[0];
+            long e = ptr[1];
+
+            // 다시 차곡차곡 쌓으면 되는 경우
+            if (s >= lastIdx) {
+//                System.out.println("=========s >= lastIdx============");
+                lastIdx = s;
+                long length = e - s;
+//                System.out.println("length = " + length);
+                long share = length / L;
+//                System.out.println("share = " + share);
+                long remainder = length % L;
+//                System.out.println("remainder = " + remainder);
+                ans += share + (remainder > 0 ? 1 : 0); // 널빤지 개수 추가
+//                System.out.println("ans = " + ans);
+                lastIdx += (share + (remainder > 0 ? 1 : 0)) * L;
+//                System.out.println("lastIdx = " + lastIdx);
+            } else if (lastIdx < e) { // 중간에 마무리가 된 상태에서 널빤지를 더 깔아야 하는 상황인 경우
+//                System.out.println("=========lastIdx < e============");
+                long length = e - lastIdx;
+//                System.out.println("length = " + length);
+                long share = length / L;
+//                System.out.println("share = " + share);
+                long remainder = length % L;
+//                System.out.println("remainder = " + remainder);
+                ans += share + (remainder > 0 ? 1 : 0); // 널빤지 개수 추가
+//                System.out.println("ans = " + ans);
+                lastIdx += (share + (remainder > 0 ? 1 : 0)) * L;
+//                System.out.println("lastIdx = " + lastIdx);
+            }
+        }
+        sb.append(ans);
+        br.close();
+        bw.write(sb.toString());
+        bw.flush();
+        bw.close();
+    }
+}


### PR DESCRIPTION
# 🔧 백준 1911 흙길보수하기

### 🤔 Intuition

첫 인상에서 그리디/Meeting-room-problem과 유사해보였습니다.
그리디로 선택을 한다고 할 때, 예외가 있는지 고민해봤는데
결국 널빤지를 최소한으로 깔아야 하니 최대한 길게 배치하는게 좋다는 건 자명하면서,
널빤지 영역을 빠짐없이 커버해야 하니까 결국 시작점을 기준으로 그리디하게 배치하면 문제 없겠다 싶었습니다.

다만, 하나의 널빤지로 두 웅덩이를 커버할 경우, 이를 체크할 수 있냐 없냐가 포인트였던 것 같고,
저는 이걸 마지막으로 널빤지를 두었던 좌표 +1 좌표(다음 널빤지를 놓기 시작할 위치) `int lastIdx`라는 변수로 저장하여 이를 기준으로 다음 웅덩이의 시작점 `int s`와 끝점 `int e`를 이용해 `if` 분기로 검사해 주었습니다.
이 과정에서 널빤지 개수가 좌표에 따라 딱 떨어지지 않는 경우가 더 많을테니 나누기와 나머지 연산을 적절히 활용하여 널빤지 개수를 계산하는 게 필요했습니다.

### 🔎 Algorithm & Complexity

- algorithm : greedy
- time complexity : O(N log N) - 물웅덩이 개수만큼 iteration O(N) + 물웅덩이 좌표들 sort O(N * log N)
- space complexity : O(N) - 물웅덩이 좌표를 저장 O(N)

### 🧑‍💻 Logic

1. 웅덩이 좌표들을 `int[]`으로 저장합니다. (이때 범위가 [start, end) 꼴임을 주의
2. 웅덩이 좌표를 iteration하면서 (s,e) 튜플을 '마지막으로 널빤지를 놓은 위치 `lastIdx`' 와 비교
3. 만약 `lastIdx`가 웅덩이 시작점보다 작거나 같으면 그대로 널빤지 깔면 됨
4. 만약 시작점보다는 크고, end 보다는 작으면 남은 길이만큼만 널빤지 깔면 됨
5. 그 외 경우에는 널빤지를 굳이 깔 필요 없으니 pass