### PR TITLE
[BOJ]2116/골드5/308ms/2h/정연서 외 2건

### DIFF
--- a/Yeonseo_Jung/BOJ_18808_스티커_붙이기.java
+++ b/Yeonseo_Jung/BOJ_18808_스티커_붙이기.java
@@ -1,0 +1,111 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayDeque;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
+public class BOJ_18808_스티커_붙이기 {
+    static int N, M, K;
+    static boolean[][] board;
+    static Queue<boolean[][]> stickers;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        N = Integer.parseInt(st.nextToken());
+        M = Integer.parseInt(st.nextToken());
+        K = Integer.parseInt(st.nextToken());
+        board = new boolean[N][M];
+        stickers = new ArrayDeque<>();
+        for (int i = 0; i < K; i++) {
+            st = new StringTokenizer(br.readLine());
+            int x = Integer.parseInt(st.nextToken());
+            int y = Integer.parseInt(st.nextToken());
+
+            boolean[][] sticker = new boolean[x][y];
+            for (int j = 0; j < x; j++) {
+                st = new StringTokenizer(br.readLine());
+                for (int k = 0; k < y; k++) {
+                    sticker[j][k] = st.nextToken().equals("1");
+                }
+            }
+            stickers.add(sticker);
+        }
+        simulation();
+    }
+
+    static void simulation() {
+        while (!stickers.isEmpty()) {
+            boolean[][] sticker = stickers.peek();
+            stick:
+            for (int i = 0; i < 4; i++) {
+                if (i > 0) {
+                    sticker = rotateSticker(sticker);
+                }
+                for (int j = 0; j < N; j++) {
+                    for (int k = 0; k < M; k++) {
+                        if (canStick(j, k, sticker)) {
+                            putSticker(j, k, sticker);
+                            break stick;
+                        }
+                    }
+                }
+            }
+            stickers.poll();
+        }
+        printAnswer();
+    }
+
+    private static boolean[][] rotateSticker(boolean[][] arr) {
+        int x = arr.length;
+        int y = arr[0].length;
+        boolean[][] rotArr = new boolean[y][x];
+
+        int rX = rotArr.length;
+        int rY = rotArr[0].length;
+        for (int i = 0; i < rX; i++) {
+            for (int j = 0; j < rY; j++) {
+                rotArr[i][j] = arr[rY - 1 - j][i];
+            }
+        }
+        return rotArr;
+    }
+
+    private static boolean canStick(int row, int col, boolean[][] sticker) {
+        if (row + sticker.length > N || col + sticker[0].length > M) {
+            return false;
+        }
+
+        for (int i = 0; i < sticker.length; i++) {
+            for (int j = 0; j < sticker[i].length; j++) {
+                if (sticker[i][j] && board[row + i][col + j]) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+    private static void putSticker(int row, int col, boolean[][] sticker) {
+        for (int i = 0; i < sticker.length; i++) {
+            for (int j = 0; j < sticker[i].length; j++) {
+                if (sticker[i][j]) {
+                    board[row + i][col + j] = true;
+                }
+            }
+        }
+    }
+
+    private static void printAnswer() {
+        int cnt = 0;
+        for (int i = 0; i < N; i++) {
+            for (int j = 0; j < M; j++) {
+                if (board[i][j]) {
+                    cnt++;
+                }
+            }
+        }
+        System.out.println(cnt);
+    }
+}

--- a/Yeonseo_Jung/BOJ_2116_주사위_쌓기.java
+++ b/Yeonseo_Jung/BOJ_2116_주사위_쌓기.java
@@ -1,0 +1,86 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class BOJ_2116_주사위_쌓기 {
+    final static int DICE_NUM = 6;
+    static int N, answer;
+    static int[][] dices, copyDices;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        N = Integer.parseInt(br.readLine());
+        dices = new int[N][DICE_NUM];
+        copyDices = new int[N][DICE_NUM];
+        for (int i = 0; i < N; i++) {
+            StringTokenizer st = new StringTokenizer(br.readLine());
+            for (int j = 0; j < DICE_NUM; j++) {
+                dices[i][j] = Integer.parseInt(st.nextToken());
+                copyDices[i][j] = dices[i][j];
+            }
+        }
+        getMaxAnswer();
+    }
+
+    private static void getMaxAnswer() {
+        for (int i = 0; i < DICE_NUM; i++) {
+            simulation(0, dices[0][i]);
+        }
+        System.out.println(answer);
+    }
+
+    private static void clearPair(int curDice, int firstIdx, int pairIdx) {
+        dices[curDice][firstIdx] = 0;
+        dices[curDice][pairIdx] = 0;
+    }
+
+    private static void simulation(int curDice, int curNum) {
+        if (curDice == N) {
+            int value = calculateValue();
+            initDices();
+            answer = Math.max(answer, value);
+            return;
+        }
+
+        for (int i = 0; i < DICE_NUM; i++) {
+            if (dices[curDice][i] == curNum) {
+                int pairIdx = findPairIdx(i);
+                int nextNum = dices[curDice][pairIdx];
+                clearPair(curDice, i, pairIdx);
+                simulation(curDice + 1, nextNum);
+            }
+        }
+    }
+
+    private static void initDices() {
+        for (int i = 0; i < N; i++) {
+            dices[i] = copyDices[i].clone();
+        }
+    }
+
+    private static int calculateValue() {
+        int value = 0;
+        for (int i = 0; i < N; i++) {
+            int max = 0;
+            for (int j = 0; j < DICE_NUM; j++) {
+                if (max < dices[i][j]) {
+                    max = dices[i][j];
+                }
+            }
+            value += max;
+        }
+        return value;
+    }
+
+    private static int findPairIdx(int idx) {
+        if (idx == 0) {
+            return 5;
+        } else if (idx < 3) {
+            return (idx + 2);
+        } else if (idx < 5) {
+            return (idx - 2);
+        }
+        return 0;
+    }
+}

--- a/Yeonseo_Jung/BOJ_2504_괄호의_값.java
+++ b/Yeonseo_Jung/BOJ_2504_괄호의_값.java
@@ -5,11 +5,11 @@ import java.util.Stack;
 
 public class BOJ_2504_괄호의_값 {
     static class Bracket {
-        char b;
+        char value;
         int num;
 
-        public Bracket(char b) {
-            this.b = b;
+        public Bracket(char value) {
+            this.value = value;
             this.num = 0;
         }
     }
@@ -20,16 +20,16 @@ public class BOJ_2504_괄호의_값 {
         Stack<Bracket> st = new Stack<>();
         int answer = 0, curScore = 0;
         for (int i = 0, size = input.length(); i < size; i++) {
-            char b = input.charAt(i);
-            if (b == '(' || b == '[') {
-                st.push(new Bracket(b));
+            char cur = input.charAt(i);
+            if (cur == '(' || cur == '[') {
+                st.push(new Bracket(cur));
             } else {
                 if (st.isEmpty()) {
                     answer = 0;
                     break;
                 }
                 Bracket curB = st.peek();
-                if (b == ')' && curB.b == '(') {
+                if (cur == ')' && curB.value == '(') {
                     curScore = curB.num == 0 ? 2 : 2 * curB.num;
                     st.pop();
                     if (!st.isEmpty()) {
@@ -37,7 +37,7 @@ public class BOJ_2504_괄호의_값 {
                     } else {
                         answer += curScore;
                     }
-                } else if (b == ']' && curB.b == '[') {
+                } else if (cur == ']' && curB.value == '[') {
                     curScore = curB.num == 0 ? 3 : 3 * curB.num;
                     st.pop();
                     if (!st.isEmpty()) {

--- a/Yeonseo_Jung/BOJ_2504_괄호의_값.java
+++ b/Yeonseo_Jung/BOJ_2504_괄호의_값.java
@@ -1,0 +1,56 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Stack;
+
+public class BOJ_2504_괄호의_값 {
+    static class Bracket {
+        char b;
+        int num;
+
+        public Bracket(char b) {
+            this.b = b;
+            this.num = 0;
+        }
+    }
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        String input = br.readLine();
+        Stack<Bracket> st = new Stack<>();
+        int answer = 0, curScore = 0;
+        for (int i = 0, size = input.length(); i < size; i++) {
+            char b = input.charAt(i);
+            if (b == '(' || b == '[') {
+                st.push(new Bracket(b));
+            } else {
+                if (st.isEmpty()) {
+                    answer = 0;
+                    break;
+                }
+                Bracket curB = st.peek();
+                if (b == ')' && curB.b == '(') {
+                    curScore = curB.num == 0 ? 2 : 2 * curB.num;
+                    st.pop();
+                    if (!st.isEmpty()) {
+                        st.peek().num += curScore;
+                    } else {
+                        answer += curScore;
+                    }
+                } else if (b == ']' && curB.b == '[') {
+                    curScore = curB.num == 0 ? 3 : 3 * curB.num;
+                    st.pop();
+                    if (!st.isEmpty()) {
+                        st.peek().num += curScore;
+                    } else {
+                        answer += curScore;
+                    }
+                }
+            }
+        }
+        if (!st.isEmpty()) {
+            answer = 0;
+        }
+        System.out.println(answer);
+    }
+}


### PR DESCRIPTION
[2116] 주사위 쌓기
밑면을 정하고 나면 주사위의 밑면과 윗면을 제외한 네 개의 옆면 중 최댓값들을 찾아 더해주면 되는 문제였습니다.
구현을 하는 중에 쓸데없는 조건과 분기를 하다보니 겉잡을 수 없이 뇌절을 하고 있었고,,, 디버깅 끝에 겨우겨우 다시 돌아왔습니다
바보같이 풀이한 것 같아 굉장히 아쉽습니다..

---

[2504] 괄호의 값 
정말 오랜만에 아이디어가 생각보다 금방 떠올랐고 또 한번에 끝낼 수 있어서 너무 즐거웠읍니다.
괄호 문제니까 stack일 것 같긴 한데 괄호가 내부에 다른 괄호를 포함하고 있는지의 여부를 어떻게 확인할까 고민하다가 괄호와 num을 인자로 갖는 Bracket 클래스를 만들어 다음과 같은 로직을 생각해봤습니다. 이때 num에는 포함하고 있는 괄호 쌍의 점수를 의미합니다!

여는 괄호인 경우: stack에 push
닫는 괄호인 경우: stack의 peek 값과 쌍을 이루면 stack에서 pop()하고, 해당 괄호쌍은 괄호의 종류에 따라 2 또는 3점(괄호 점수로 지칭)을 얻게 됩니다. 이때, 여는 괄호의 num이 존재하면 해당 괄호가 내부에 다른 괄호쌍을 포함하고 있다는 뜻이므로 num과 괄호 점수를 곱해 스코어를 계산합니다. 이후, stack에 괄호가 있다면 방금 전 계산된 괄호 쌍을 포함하고 있다는 뜻이므로 해당 여는 괄호의 num 값에 스코어를 더해줍니다. 반면 더이상 stack이 없다면 현재 스코어를 answer에 더해줍니다. (()[]  올바른 괄호열의 경우)

입력값을 모두 탐색하고 나서 stack이 비어있지 않다면 올바르지 않은 괄호열이므로 answer는 0이고, stack이 비어있다면 기존 answer를 출력합니닷

---

[18808] 색종이 붙이기 
어려운 문제는 아니었으나 자꾸 8%에서 틀렸습니다가 떠서 눈물이 차올랐습니다... 천재만재 승헌이와 권일이의 도움으로 오류를 발견할 수 있었습었는데, `sticker = rotate(sticker, degree)` 가 문제였습니다. 회전시킬 배열과 degree값을 받아놓고 이를 원본 배열에 덮어씌웠기 때문에 회전로직에는 이상이 없었음에도 불구하고 90도 회전시킨 배열을 그 다음에는 180도 더 회전시키는 문제가 발생하고 있었습니다.  구현이 힘들면 디버깅이라도 더 착실히 하자......